### PR TITLE
Add handler to validate calls

### DIFF
--- a/chassis/test/util/params_test.py
+++ b/chassis/test/util/params_test.py
@@ -11,11 +11,8 @@ from chassis.util import params
 class TestParamParser(unittest.TestCase):
 
     def setUp(self):
-        self.handler = mock.Mock()
-        self.handler.request = mock.Mock()
+        self.handler = mock.MagicMock()
         self.handler.request.arguments = {}
-
-        self.handler.get = mock.Mock()
         self.handler.get.__name__ = "get"
 
         self.bar_validator = mock.Mock()

--- a/chassis/test/util/params_test.py
+++ b/chassis/test/util/params_test.py
@@ -15,8 +15,8 @@ class TestParamParser(unittest.TestCase):
         self.handler.request = mock.Mock()
         self.handler.request.arguments = {}
 
-        self.get = mock.Mock()
-        self.get.__name__ = "get"
+        self.handler.get = mock.Mock()
+        self.handler.get.__name__ = "get"
 
         self.bar_validator = mock.Mock()
         self.bar_validator.validate = mock.Mock(return_value='bar')
@@ -36,18 +36,19 @@ class TestParamParser(unittest.TestCase):
         # Apply the decorator we're testing to the mock get method
         get = params.parse([
             ('foo', {'validators': self.bar_validator, 'required': False})
-            ])(self.get)
+            ])(self.handler.get)
 
         # Called without parameters, raises an exception
         get(self.handler)
-        self.get.assert_called_with(self.handler, foo=None)
+        self.handler.get.assert_called_with(self.handler, foo=None)
 
         # Called with parameters, returns validated parameter
         self.handler.request.arguments['foo'] = 'Foobar'
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.get.assert_called_with(self.handler, foo='bar')
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, foo='bar')
 
     def test_default_parameter(self):
 
@@ -57,25 +58,26 @@ class TestParamParser(unittest.TestCase):
                 'validators': self.bar_validator,
                 'required': False,
                 'default': 42
-                })])(self.get)
+                })])(self.handler.get)
 
         # Called without parameters, uses default value
         get(self.handler)
-        self.get.assert_called_with(self.handler, foo=42)
+        self.handler.get.assert_called_with(self.handler, foo=42)
 
         # Called with parameters, returns validated parameter
         self.handler.request.arguments['foo'] = 'Foobar'
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.get.assert_called_with(self.handler, foo='bar')
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, foo='bar')
 
     def test_required_parameter(self):
 
         # Apply the decorator we're testing to the mock get method
         get = params.parse([
             ('foo', {'validators': [self.bar_validator], 'required': True})
-            ])(self.get)
+            ])(self.handler.get)
 
         # Called without parameters, raises an exception
         self.assertRaises(web.HTTPError,
@@ -86,15 +88,16 @@ class TestParamParser(unittest.TestCase):
         self.handler.request.arguments['foo'] = 'Foobar'
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.get.assert_called_with(self.handler, foo='bar')
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, foo='bar')
 
     def test_failing_parameter(self):
 
         # Apply the decorator we're testing to the mock get method
         get = params.parse([
             ('foo', {'validators': [self.fail_validator], 'required': True})
-            ])(self.get)
+            ])(self.handler.get)
 
         # Called without parameters, raises an exception
         self.assertRaises(web.HTTPError,
@@ -114,7 +117,7 @@ class TestParamParser(unittest.TestCase):
             ('foo', {'validators': self.bar_validator, 'required': True}),
             ('spam', {'validators': self.bat_validator, 'required': True}),
             ('eggs', {'validators': self.baz_validator, 'required': False})
-            ])(self.get)
+            ])(self.handler.get)
 
         # Called without parameters, raises an exception
         self.assertRaises(web.HTTPError,
@@ -127,9 +130,11 @@ class TestParamParser(unittest.TestCase):
 
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.bat_validator.validate.assert_called_with('Canned Meat')
-        self.get.assert_called_with(self.handler,
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.bat_validator.validate.assert_called_with('Canned Meat',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler,
                                     foo='bar',
                                     spam='bat',
                                     eggs=None)
@@ -141,9 +146,10 @@ class TestParamParser(unittest.TestCase):
 
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.bat_validator.validate.assert_called_with('Canned Meat')
-        self.get.assert_called_with(self.handler,
+        self.bar_validator.validate.assert_called_with('Foobar', self.handler)
+        self.bat_validator.validate.assert_called_with('Canned Meat',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler,
                                     foo='bar',
                                     spam='bat',
                                     eggs='baz')
@@ -152,7 +158,7 @@ class TestParamParser(unittest.TestCase):
         # Apply the decorator we're testing to the mock get method
         get = params.parse([
             ('foo', {'validators': self.bar_validator, 'required': True})
-            ])(self.get)
+            ])(self.handler.get)
 
         # Called without parameters, raises an exception
         self.assertRaises(web.HTTPError,
@@ -164,8 +170,9 @@ class TestParamParser(unittest.TestCase):
         self.handler.request.arguments['extra'] = 'Do Not Want'
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.get.assert_called_with(self.handler, foo='bar')
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, foo='bar')
 
     def test_chained_validators(self):
 
@@ -176,7 +183,7 @@ class TestParamParser(unittest.TestCase):
                                self.bat_validator,
                                self.baz_validator],
                 'required': True
-                })])(self.get)
+                })])(self.handler.get)
 
         # Called without parameters, raises an exception
 
@@ -190,11 +197,14 @@ class TestParamParser(unittest.TestCase):
         self.handler.request.arguments['foo'] = 'Foobar'
         get(self.handler)
 
-        self.bar_validator.validate.assert_called_with('Foobar')
-        self.bat_validator.validate.assert_called_with('bar')
-        self.baz_validator.validate.assert_called_with('bat')
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.bat_validator.validate.assert_called_with('bar',
+                                                       self.handler)
+        self.baz_validator.validate.assert_called_with('bat',
+                                                       self.handler)
 
-        self.get.assert_called_with(self.handler, foo='baz')
+        self.handler.get.assert_called_with(self.handler, foo='baz')
 
     def test_chained_validators_fail(self):
 
@@ -205,7 +215,7 @@ class TestParamParser(unittest.TestCase):
                                self.bat_validator,
                                self.fail_validator],
                 'required': True
-                })])(self.get)
+                })])(self.handler.get)
 
         # Called without parameters, raises an exception
 

--- a/chassis/test/util/validators_test.py
+++ b/chassis/test/util/validators_test.py
@@ -15,7 +15,7 @@ class TestBaseValidator(test.TestCase):
 
     def test_validate_not_implemented(self):
         validator = validators.BaseValidator()
-        self.assertRaises(NotImplementedError, validator.validate, 'foo')
+        self.assertRaises(NotImplementedError, validator.validate, 'foo', None)
 
     def test_override_message(self):
         new_message = "Foo Message."
@@ -47,7 +47,7 @@ class TestBoolean(test.TestCase):
                        '1', True, 1)
 
         for value in true_values:
-            self.assertEqual(True, self.validator.validate(value))
+            self.assertEqual(True, self.validator.validate(value, None))
 
     def test_false_inputs(self):
 
@@ -56,7 +56,7 @@ class TestBoolean(test.TestCase):
                         '0', False, 0)
 
         for value in false_values:
-            self.assertEqual(False, self.validator.validate(value))
+            self.assertEqual(False, self.validator.validate(value, None))
 
     def test_error_inputs(self):
 
@@ -65,55 +65,55 @@ class TestBoolean(test.TestCase):
         for value in error_values:
             self.assertRaises(validators.ValidationError,
                               self.validator.validate,
-                              value)
+                              value, None)
 
 
 class TestString(test.TestCase):
 
     def test_basic_string(self):
         validator = validators.String()
-        self.assertEqual('foo', validator.validate('foo'))
+        self.assertEqual('foo', validator.validate('foo', None))
 
     def test_not_a_string(self):
         validator = validators.String()
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          42)
+                          42, None)
 
     def test_min_length(self):
         validator = validators.String(min_length=3)
 
-        self.assertEqual('foo', validator.validate('foo'))
-        self.assertEqual('foobar', validator.validate('foobar'))
+        self.assertEqual('foo', validator.validate('foo', None))
+        self.assertEqual('foobar', validator.validate('foobar', None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'fo')
+                          'fo', None)
 
     def test_max_length(self):
         validator = validators.String(max_length=4)
 
-        self.assertEqual('foo', validator.validate('foo'))
-        self.assertEqual('fooz', validator.validate('fooz'))
+        self.assertEqual('foo', validator.validate('foo', None))
+        self.assertEqual('fooz', validator.validate('fooz', None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'fooze')
+                          'fooze', None)
 
     def test_min_and_max_lengths(self):
         validator = validators.String(min_length=2, max_length=4)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'f')
+                          'f', None)
 
-        self.assertEqual('fo', validator.validate('fo'))
-        self.assertEqual('foo', validator.validate('foo'))
-        self.assertEqual('fooz', validator.validate('fooz'))
+        self.assertEqual('fo', validator.validate('fo', None))
+        self.assertEqual('foo', validator.validate('foo', None))
+        self.assertEqual('fooz', validator.validate('fooz', None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'fooze')
+                          'fooze', None)
 
 
 class TestRegex(test.TestCase):
@@ -122,151 +122,151 @@ class TestRegex(test.TestCase):
         self.validator = validators.Regex('[a-zA-Z0-9]{2,4}')
 
     def test_regex_pass(self):
-        self.assertEqual('f0', self.validator.validate('f0'))
-        self.assertEqual('f00', self.validator.validate('f00'))
-        self.assertEqual('f00z', self.validator.validate('f00z'))
+        self.assertEqual('f0', self.validator.validate('f0', None))
+        self.assertEqual('f00', self.validator.validate('f00', None))
+        self.assertEqual('f00z', self.validator.validate('f00z', None))
 
     def test_regex_fail(self):
 
         self.assertRaises(validators.ValidationError,
                           self.validator.validate,
-                          'f')
+                          'f', None)
 
         self.assertRaises(validators.ValidationError,
                           self.validator.validate,
-                          'fooze')
+                          'fooze', None)
 
         self.assertRaises(validators.ValidationError,
                           self.validator.validate,
-                          '***')
+                          '***', None)
 
 
 class TestInteger(test.TestCase):
 
     def test_basic_integer(self):
         validator = validators.Integer()
-        self.assertEqual(42, validator.validate('42'))
-        self.assertEqual(42, validator.validate(42))
-        self.assertEqual(0, validator.validate('0'))
-        self.assertEqual(-10, validator.validate('-10'))
+        self.assertEqual(42, validator.validate('42', None))
+        self.assertEqual(42, validator.validate(42, None))
+        self.assertEqual(0, validator.validate('0', None))
+        self.assertEqual(-10, validator.validate('-10', None))
 
     def test_not_an_integer(self):
         validator = validators.Integer()
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          31.2)
+                          31.2, None)
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          '42.1')
+                          '42.1', None)
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'foo')
+                          'foo', None)
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          '10-21')
+                          '10-21', None)
 
     def test_min_integer(self):
         validator = validators.Integer(minimum=2)
-        self.assertEqual(2, validator.validate('2'))
-        self.assertEqual(42, validator.validate(42))
+        self.assertEqual(2, validator.validate('2', None))
+        self.assertEqual(42, validator.validate(42, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          1)
+                          1, None)
 
     def test_max_integer(self):
         validator = validators.Integer(maximum=42)
-        self.assertEqual(1, validator.validate('1'))
-        self.assertEqual(42, validator.validate(42))
+        self.assertEqual(1, validator.validate('1', None))
+        self.assertEqual(42, validator.validate(42, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          43)
+                          43, None)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          10000000)
+                          10000000, None)
 
     def test_min_and_max_integer(self):
         validator = validators.Integer(minimum=2, maximum=42)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          1)
+                          1, None)
 
-        self.assertEqual(2, validator.validate('2'))
-        self.assertEqual(10, validator.validate('10'))
-        self.assertEqual(42, validator.validate(42))
+        self.assertEqual(2, validator.validate('2', None))
+        self.assertEqual(10, validator.validate('10', None))
+        self.assertEqual(42, validator.validate(42, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          43)
+                          43, None)
 
 
 class TestNumber(test.TestCase):
 
     def test_basic_number(self):
         validator = validators.Number()
-        self.assertEqual(42, validator.validate('42'))
-        self.assertEqual(42, validator.validate(42))
-        self.assertEqual(0, validator.validate('0'))
-        self.assertEqual(-10, validator.validate('-10'))
-        self.assertEqual(1.2, validator.validate('1.2'))
-        self.assertEqual(-10.345, validator.validate('-10.345'))
+        self.assertEqual(42, validator.validate('42', None))
+        self.assertEqual(42, validator.validate(42, None))
+        self.assertEqual(0, validator.validate('0', None))
+        self.assertEqual(-10, validator.validate('-10', None))
+        self.assertEqual(1.2, validator.validate('1.2', None))
+        self.assertEqual(-10.345, validator.validate('-10.345', None))
 
     def test_not_a_number(self):
         validator = validators.Number()
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          'foobar')
+                          'foobar', None)
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          '10.2.b')
+                          '10.2.b', None)
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          '10*21')
+                          '10*21', None)
 
     def test_min_number(self):
         validator = validators.Number(minimum=2.5)
 
-        self.assertEqual(2.5, validator.validate('2.5'))
-        self.assertEqual(42, validator.validate(42))
+        self.assertEqual(2.5, validator.validate('2.5', None))
+        self.assertEqual(42, validator.validate(42, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          2.4999)
+                          2.4999, None)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          1)
+                          1, None)
 
     def test_max_number(self):
         validator = validators.Number(maximum=42.42)
 
-        self.assertEqual(1, validator.validate('1'))
-        self.assertEqual(42.42, validator.validate(42.42))
+        self.assertEqual(1, validator.validate('1', None))
+        self.assertEqual(42.42, validator.validate(42.42, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          42.43000001)
+                          42.43000001, None)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          10000000)
+                          10000000, None)
 
     def test_min_and_max_number(self):
         validator = validators.Number(minimum=2.1, maximum=42.9)
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          2.09)
+                          2.09, None)
 
-        self.assertEqual(2.1, validator.validate('2.1'))
-        self.assertEqual(10, validator.validate('10'))
-        self.assertEqual(42.9, validator.validate(42.9))
+        self.assertEqual(2.1, validator.validate('2.1', None))
+        self.assertEqual(10, validator.validate('10', None))
+        self.assertEqual(42.9, validator.validate(42.9, None))
 
         self.assertRaises(validators.ValidationError,
                           validator.validate,
-                          42.91)
+                          42.91, None)

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -78,7 +78,7 @@ def parse(parameters):
                     try:
                         kwargs[key] = _apply_validator_chain(
                             properties.get('validators', []), value, self)
-                    except validators.ValidationError, err:
+                    except validators.ValidationError as err:
                         errors.append(err)
                 else:
                     if properties.get('required', False):

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -3,7 +3,7 @@
 import six
 from tornado import web
 
-from chassis import util
+from chassis.util import decorators
 
 
 def _fetch_arguments(handler, method):
@@ -60,7 +60,7 @@ def parse(parameters):
     """
     # pylint: disable=protected-access
 
-    @util.decorators.include_original
+    @decorators.include_original
     def decorate(method):
         """Setup returns this decorator, which is called on the method."""
 

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -4,6 +4,7 @@ import six
 from tornado import web
 
 from chassis.util import decorators
+from chassis.util import validators
 
 
 def _fetch_arguments(handler, method):
@@ -25,7 +26,7 @@ def _fetch_arguments(handler, method):
     return arguments
 
 
-def _apply_validator_chain(validators, value):
+def _apply_validator_chain(validators, value, handler):
     """Apply validators in sequence to a value."""
 
     if hasattr(validators, 'validate'):  # not a list
@@ -33,7 +34,7 @@ def _apply_validator_chain(validators, value):
 
     for validator in validators:
         if hasattr(validator, 'validate'):
-            value = validator.validate(value)
+            value = validator.validate(value, handler)
         else:
             raise web.HTTPError(500)
     return value
@@ -70,11 +71,15 @@ def parse(parameters):
             arguments = _fetch_arguments(self, method)
 
             kwargs = {}
+            errors = []
             for key, properties in parameters:
                 if key in arguments:
                     value = arguments[key]
-                    validators = properties.get('validators', [])
-                    kwargs[key] = _apply_validator_chain(validators, value)
+                    try:
+                        kwargs[key] = _apply_validator_chain(
+                            properties.get('validators', []), value, self)
+                    except validators.ValidationError, err:
+                        errors.append(err)
                 else:
                     if properties.get('required', False):
                         raise web.HTTPError(
@@ -87,6 +92,8 @@ def parse(parameters):
                             kwargs[key] = properties['default']
                         else:
                             kwargs[key] = None
+            if errors:
+                raise web.HTTPError(400, 'There were %s errors' % len(errors) )
             return method(self, *args, **kwargs)
 
         # TODO: Autogenerate documentation data for parameters.

--- a/chassis/util/validators.py
+++ b/chassis/util/validators.py
@@ -39,7 +39,7 @@ class BaseValidator(object):
 
         raise ValidationError(self.get_message())
 
-    def validate(self, unused_value):
+    def validate(self, unused_value, unused_handler):
         """Override this to implement validation logic.
 
         Return the validated value or call self.fail() to raise a
@@ -57,7 +57,7 @@ class Boolean(BaseValidator):
     documentation = "Truthy value: Prefered `true` or `false`"
     message = "Valid boolean required"
 
-    def validate(self, value):
+    def validate(self, value, unused_handler):
         if isinstance(value, six.string_types):
             value = value.lower()
 
@@ -86,7 +86,7 @@ class String(BaseValidator):
         super(String, self).__init__(message=message,
                                      documentation=documentation)
 
-    def validate(self, value):
+    def validate(self, value, unused_handler):
         if not isinstance(value, six.string_types):
             self.fail()
 
@@ -115,7 +115,7 @@ class Regex(BaseValidator):
         super(Regex, self).__init__(message=message,
                                     documentation=documentation)
 
-    def validate(self, value):
+    def validate(self, value, unused_handler):
         match = self.pattern.match(value)
 
         if match and value == match.group():
@@ -139,7 +139,7 @@ class Number(BaseValidator):
         super(Number, self).__init__(message=message,
                                      documentation=documentation)
 
-    def validate(self, value):
+    def validate(self, value, unused_handler):
         try:
             value = float(value)
         except ValueError:
@@ -167,10 +167,10 @@ class Integer(Number):
                                       message=message,
                                       documentation=documentation)
 
-    def validate(self, value):
+    def validate(self, value, handler):
 
         # Do the Number validation first
-        float_value = super(Integer, self).validate(value)
+        float_value = super(Integer, self).validate(value, handler)
 
         int_value = int(float_value)
 


### PR DESCRIPTION
Adds an argument representing the tornado Handler object to validator.validate() calls, adapts params.parse() to inject that value, and updates all tests.

This is not used in the library, but can be used in application-specific validators to access config or runtime data that may weigh in the validation.