### PR TITLE
Support linting of individual files via command-line

### DIFF
--- a/chassis/tools/lint.py
+++ b/chassis/tools/lint.py
@@ -11,6 +11,7 @@ except ImportError:
     print "Can't import module pylint. Did you install it?"
     sys.exit(-1)
 
+
 # either use the files given on the command line or all '*.py' files
 # located in and beyond the working directory
 FILES = []
@@ -25,22 +26,15 @@ else:
             os.path.join(dirpath, filename)
             for filename in filenames
             if ".py" == filename[-3:]
-        )
+
 
 # A list of messages that should not be printed by pylint.
 SUPRESSED_MESSAGES = [
-    'I0011',  # Inline option disables a message or a messages category.
-    # 'W0312',  # Some mixed tabs and spaces in a module.
-    'too-few-public-methods',
-    'too-many-public-methods',
-    # 'import-error',
+    # 'I0011',  # Inline option disables a message or a messages category.
+    # 'too-few-public-methods',
+    # 'too-many-public-methods',
     'fixme',
-    'too-many-lines',
-    'cyclic-import',
-    'duplicate-code',
-    'file-ignored',
-    'interface-not-implemented',
-    'abstract-class-not-used'
+    # 'file-ignored'
 ]
 
 

--- a/chassis/tools/lint.py
+++ b/chassis/tools/lint.py
@@ -11,25 +11,36 @@ except ImportError:
     print "Can't import module pylint. Did you install it?"
     sys.exit(-1)
 
-
 # either use the files given on the command line or all '*.py' files
 # located in and beyond the working directory
 FILES = []
-for dirpath, dirnames, filenames in os.walk(os.getcwd()):
-    FILES.extend(
-        os.path.join(dirpath, filename)
-        for filename in filenames
-        if ".py" == filename[-3:]
-    )
 
+# pylint: disable=invalid-name
+argc = len(sys.argv)
+if argc > 1:
+    FILES = sys.argv[1:argc]
+else:
+    for dirpath, dirnames, filenames in os.walk(os.getcwd()):
+        FILES.extend(
+            os.path.join(dirpath, filename)
+            for filename in filenames
+            if ".py" == filename[-3:]
+        )
 
 # A list of messages that should not be printed by pylint.
 SUPRESSED_MESSAGES = [
-    # 'I0011',  # Inline option disables a message or a messages category.
-    # 'too-few-public-methods',
-    # 'too-many-public-methods',
+    'I0011',  # Inline option disables a message or a messages category.
+    # 'W0312',  # Some mixed tabs and spaces in a module.
+    'too-few-public-methods',
+    'too-many-public-methods',
+    # 'import-error',
     'fixme',
-    # 'file-ignored'
+    'too-many-lines',
+    'cyclic-import',
+    'duplicate-code',
+    'file-ignored',
+    'interface-not-implemented',
+    'abstract-class-not-used'
 ]
 
 


### PR DESCRIPTION
```
ryan 福 ~/Projects/chassis/chassis ➤ 89c306c|feature/lint-individual-files⚡
8699 ± : python tools/lint.py tools/lint.py                                       [11d1h45m] ✹
No config file found, using default configuration
(env)
ryan 福 ~/Projects/chassis/chassis ➤ 89c306c|feature/lint-individual-files⚡
```

:horse: Yee haw! :cactus: 