### PR TITLE
Remove missing parenthese in lint.py

### DIFF
--- a/chassis/tools/lint.py
+++ b/chassis/tools/lint.py
@@ -26,7 +26,7 @@ else:
             os.path.join(dirpath, filename)
             for filename in filenames
             if ".py" == filename[-3:]
-
+        )
 
 # A list of messages that should not be printed by pylint.
 SUPRESSED_MESSAGES = [


### PR DESCRIPTION
Yikes.

Missing parenthesis from earlier commit that added individual file linting support.

This PR adds back that parenthesis.