### PR TITLE
Add parse_dict() decorator

### DIFF
--- a/chassis/services/dependency_injection/__init__.py
+++ b/chassis/services/dependency_injection/__init__.py
@@ -143,10 +143,10 @@ class ServiceFactory(object):
             factory_method = dictionary['factory-method']
 
         if 'factory-args' in dictionary:
-            factory_args =dictionary['factory-args']
+            factory_args = dictionary['factory-args']
 
         if 'factory-kwargs' in dictionary:
-            factory_kwargs =dictionary['factory-kwargs']
+            factory_kwargs = dictionary['factory-kwargs']
 
         if 'static' in dictionary:
             static = dictionary['static']
@@ -302,7 +302,6 @@ class ServiceFactory(object):
         # Replace service references
         args = self._replace_services_in_args(args)
         kwargs = self._replace_services_in_kwargs(kwargs)
-
 
         # Instantiate object
         return service_obj(*args, **kwargs)

--- a/chassis/test/example_classes.py
+++ b/chassis/test/example_classes.py
@@ -108,7 +108,7 @@ class Weeble(object):
 
 
 class TestLogger(object):
-    def __init__(self, *arg, **kwargs):
+    def __init__(self, *arg, **unused_kwargs):
         self._config = arg[0]
 
     @property

--- a/chassis/test/services/dependency_injection/resolver_test.py
+++ b/chassis/test/services/dependency_injection/resolver_test.py
@@ -186,10 +186,7 @@ class ResolverTest(unittest.TestCase):
         assert isinstance(services['foo'], Foo)
 
     def test_advanced(self):
-        """Test advanced features???
-
-        TODO: Better docstring for this.
-        """
+        """Test advanced configuration dictionary."""
 
         config = {
             'logger': {

--- a/chassis/test/services/dependency_injection/resolver_test.py
+++ b/chassis/test/services/dependency_injection/resolver_test.py
@@ -45,6 +45,8 @@ class DetectCircleTest(unittest.TestCase):
             Check that invalid argument types are
             detected and an exception is raised.
         """
+        # pylint: disable=protected-access
+
         self.assertRaises(TypeError,
                           resolver._detect_circle,
                           'not_a_dictionary')
@@ -184,6 +186,11 @@ class ResolverTest(unittest.TestCase):
         assert isinstance(services['foo'], Foo)
 
     def test_advanced(self):
+        """Test advanced features???
+
+        TODO: Better docstring for this.
+        """
+
         config = {
             'logger': {
                 'module': 'chassis.test.example_classes',

--- a/chassis/test/util/params_test.py
+++ b/chassis/test/util/params_test.py
@@ -226,3 +226,206 @@ class TestParamParser(unittest.TestCase):
         self.assertRaises(web.HTTPError,
                           get,
                           self.handler)
+
+# # # # # # #  # # # # # # # # # ## #  ##
+
+    def test_optional_parameter_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {'validators': self.bar_validator, 'required': False})
+            ])(self.handler.get)
+
+        # Called without parameters, raises an exception
+        get(self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': None})
+
+        # Called with parameters, returns validated parameter
+        self.handler.request.arguments['foo'] = 'Foobar'
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': 'bar'})
+
+    def test_default_parameter_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {
+                'validators': self.bar_validator,
+                'required': False,
+                'default': 42
+                })])(self.handler.get)
+
+        # Called without parameters, uses default value
+        get(self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': 42})
+
+        # Called with parameters, returns validated parameter
+        self.handler.request.arguments['foo'] = 'Foobar'
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': 'bar'})
+
+    def test_required_parameter_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {'validators': [self.bar_validator], 'required': True})
+            ])(self.handler.get)
+
+        # Called without parameters, raises an exception
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with parameters, returns validated parameter
+        self.handler.request.arguments['foo'] = 'Foobar'
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': 'bar'})
+
+    def test_failing_parameter_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {'validators': [self.fail_validator], 'required': True})
+            ])(self.handler.get)
+
+        # Called without parameters, raises an exception
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with parameters, raises an exception
+        self.handler.request.arguments['foo'] = 'Foobar'
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+    def test_multiple_parameter_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {'validators': self.bar_validator, 'required': True}),
+            ('spam', {'validators': self.bat_validator, 'required': True}),
+            ('eggs', {'validators': self.baz_validator, 'required': False})
+            ])(self.handler.get)
+
+        # Called without parameters, raises an exception
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with required parameters, returns validated parameters
+        self.handler.request.arguments['foo'] = 'Foobar'
+        self.handler.request.arguments['spam'] = 'Canned Meat'
+
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.bat_validator.validate.assert_called_with('Canned Meat',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler,
+                                            data={'eggs': None,
+                                                  'foo': 'bar',
+                                                  'spam': 'bat'})
+
+        # Called with all parameters, returns validated parameters
+        self.handler.request.arguments['foo'] = 'Foobar'
+        self.handler.request.arguments['spam'] = 'Canned Meat'
+        self.handler.request.arguments['eggs'] = 'Over Easy'
+
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar', self.handler)
+        self.bat_validator.validate.assert_called_with('Canned Meat',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler,
+                                            data={'foo': 'bar',
+                                                  'spam': 'bat',
+                                                  'eggs': 'baz'})
+
+    def test_extra_parameters_dict(self):
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {'validators': self.bar_validator, 'required': True})
+            ])(self.handler.get)
+
+        # Called without parameters, raises an exception
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with extra parameters, trims extra validated parameter
+        self.handler.request.arguments['foo'] = 'Foobar'
+        self.handler.request.arguments['extra'] = 'Do Not Want'
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.handler.get.assert_called_with(self.handler, data={'foo': 'bar'})
+
+    def test_chained_validators_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {
+                'validators': [self.bar_validator,
+                               self.bat_validator,
+                               self.baz_validator],
+                'required': True
+                })])(self.handler.get)
+
+        # Called without parameters, raises an exception
+
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with parameters, verifies that parameter is passed through
+        # each validator in order.
+
+        self.handler.request.arguments['foo'] = 'Foobar'
+        get(self.handler)
+
+        self.bar_validator.validate.assert_called_with('Foobar',
+                                                       self.handler)
+        self.bat_validator.validate.assert_called_with('bar',
+                                                       self.handler)
+        self.baz_validator.validate.assert_called_with('bat',
+                                                       self.handler)
+
+        self.handler.get.assert_called_with(self.handler, data={'foo': 'baz'})
+
+    # pylint: disable=invalid-name
+    def test_chained_validators_fail_dict(self):
+
+        # Apply the decorator we're testing to the mock get method
+        get = params.parse_dict([
+            ('foo', {
+                'validators': [self.bar_validator,
+                               self.bat_validator,
+                               self.fail_validator],
+                'required': True
+                })])(self.handler.get)
+
+        # Called without parameters, raises an exception
+
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+
+        # Called with parameters, raises an exception
+
+        self.handler.request.arguments['foo'] = 'Foobar'
+        self.assertRaises(web.HTTPError,
+                          get,
+                          self.handler)
+

--- a/chassis/test/util/params_test.py
+++ b/chassis/test/util/params_test.py
@@ -428,4 +428,3 @@ class TestParamParser(unittest.TestCase):
         self.assertRaises(web.HTTPError,
                           get,
                           self.handler)
-

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -122,7 +122,7 @@ def parse_dict(parameters):
 
     Usage:
 
-    @chassis.util.parameters.parse([
+    @chassis.util.parameters.parse_dict([
         ('email', {'validators': [validators.Email], 'required': True}),
         ('password', {'validators': [validators.Password], 'required': True})
         ])

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -40,6 +40,41 @@ def _apply_validator_chain(chain, value, handler):
     return value
 
 
+def _parse_arguments(self, method, parameters):
+    """Parse arguments to method, returning a dictionary."""
+
+    # TODO: Consider raising an exception if there are extra arguments.
+
+    arguments = _fetch_arguments(self, method)
+
+    arg_dict = {}
+    errors = []
+    for key, properties in parameters:
+        if key in arguments:
+            value = arguments[key]
+            try:
+                arg_dict[key] = _apply_validator_chain(
+                    properties.get('validators', []), value, self)
+            except validators.ValidationError as err:
+                errors.append(err)
+        else:
+            if properties.get('required', False):
+                raise web.HTTPError(
+                    400,
+                    ('Missing required parameter: %s'
+                     % (key, ))
+                    )
+            else:
+                if properties.get('default', None) is not None:
+                    arg_dict[key] = properties['default']
+                else:
+                    arg_dict[key] = None
+    if errors:
+        raise web.HTTPError(400, 'There were %s errors' % len(errors))
+
+    return arg_dict
+
+
 def parse(parameters):
     """Decorator to parse parameters according to a set of criteria.
 
@@ -67,33 +102,44 @@ def parse(parameters):
         def call(self, *args):
             """This is called whenever the decorated method is invoked."""
 
-            arguments = _fetch_arguments(self, method)
-
-            kwargs = {}
-            errors = []
-            for key, properties in parameters:
-                if key in arguments:
-                    value = arguments[key]
-                    try:
-                        kwargs[key] = _apply_validator_chain(
-                            properties.get('validators', []), value, self)
-                    except validators.ValidationError as err:
-                        errors.append(err)
-                else:
-                    if properties.get('required', False):
-                        raise web.HTTPError(
-                            400,
-                            ('Missing required parameter: %s'
-                             % (key, ))
-                            )
-                    else:
-                        if properties.get('default', None) is not None:
-                            kwargs[key] = properties['default']
-                        else:
-                            kwargs[key] = None
-            if errors:
-                raise web.HTTPError(400, 'There were %s errors' % len(errors))
+            kwargs = _parse_arguments(self, method, parameters)
             return method(self, *args, **kwargs)
+
+        # TODO: Autogenerate documentation data for parameters.
+
+        return call
+    return decorate
+
+
+def parse_dict(parameters):
+    """Decorator to parse parameters as a dict according to a set of criteria.
+
+    This outer method is called to set up the decorator.
+
+    Arguments:
+        parameters: An array of parameter declarations tuples in the format:
+        ('<param_name>', {'validate': [<ValidatorClass>,...], <options...>})
+
+    Usage:
+
+    @chassis.util.parameters.parse([
+        ('email', {'validators': [validators.Email], 'required': True}),
+        ('password', {'validators': [validators.Password], 'required': True})
+        ])
+    def post(self, data):
+        # Render JSON for the provided parameters
+        self.render_json({'email': data['email'], 'password': data['password']})
+    """
+    # pylint: disable=protected-access
+    @decorators.include_original
+    def decorate(method):
+        """Setup returns this decorator, which is called on the method."""
+
+        def call(self, *args):
+            """This is called whenever the decorated method is invoked."""
+
+            arg_dict = _parse_arguments(self, method, parameters)
+            return method(self, *args, data=arg_dict)
 
         # TODO: Autogenerate documentation data for parameters.
 

--- a/chassis/util/params.py
+++ b/chassis/util/params.py
@@ -128,7 +128,8 @@ def parse_dict(parameters):
         ])
     def post(self, data):
         # Render JSON for the provided parameters
-        self.render_json({'email': data['email'], 'password': data['password']})
+        self.render_json({'email': data['email'],
+                          'password': data['password']})
     """
     # pylint: disable=protected-access
     @decorators.include_original


### PR DESCRIPTION
The new `@chassis.util.params.parse_dict()` decorator is identical to `@chassis.util.params.parse()` *except* that it injects a dictionary into the method as the keyword argument `data`, instead of injecting each parameter as its own keyword argument.